### PR TITLE
feat: fetch weather events via API with fallback

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -146,8 +146,11 @@ class MetroWeatherAnalyzer {
         const analysisResults = [];
         
         for (const quarter of quarters) {
-            // 生成天气事件
-            const weatherEvents = this.weatherManager.generateWeatherEvents(quarter);
+            // 获取天气事件（优先使用API，失败则回退到模拟数据）
+            const weatherEvents = await this.weatherManager.fetchWeatherEvents(
+                quarter.startDate,
+                quarter.endDate
+            );
             
             // 计算销售影响
             const baseSales = this.salesCalculator.calculateBaseSales(quarter, quarter.year);


### PR DESCRIPTION
## Summary
- add `fetchWeatherEvents` to retrieve Environment Canada weather alerts and map them to existing event model
- fall back to simulated events when the API call fails
- use new weather event fetcher in main analysis workflow

## Testing
- `node --check js/weather-data.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3d04e98c08322ab0738cfeffd0510